### PR TITLE
Add docs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: julia
+sudo: false
+julia:
+    - 0.4
+    - 0.5
+    - nightly
+notifications:
+    email: false
+#script: # use the default script setting which is equivalent to the following
+after_success:
+    - julia -e 'Pkg.add("Documenter")'
+    - julia -e 'cd(Pkg.dir("Matching")); include(joinpath("docs", "make.jl"))'
+

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,22 @@
+using Documenter, Matching
+
+makedocs(
+    modules = [Matching],
+    format = :html,
+    sitename = "Matching.jl",
+    pages = Any[
+        "Home" => "index.md",
+        "API" => Any[
+            "Matching" => "api/Matching.md"
+        ],
+    ]
+)
+
+deploydocs(
+    repo = "github.com/oyamad/Matching.jl.git",
+    branch = "gh-pages",
+    target = "build",
+    julia  = "0.5",
+    deps = nothing,
+    make = nothing,
+)

--- a/docs/src/api/Matching.md
+++ b/docs/src/api/Matching.md
@@ -1,0 +1,28 @@
+# Matching
+
+```@meta
+CurrentModule = Matching
+DocTestSetup  = quote
+    using Matching
+end
+```
+
+## Exported
+
+```@autodocs
+Modules = [Matching]
+Private = false
+```
+
+## Internal
+
+```@autodocs
+Modules = [Matching]
+Public = false
+```
+
+## Index
+
+```@index
+Pages = ["Matching.md"]
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,19 @@
+# Matching.jl
+
+Matching algorithms in Julia.
+
+## Installation
+
+This is an unregistered package. To install, open a `Julia` session and type
+
+```julia
+Pkg.clone("https://github.com/oyamad/Matching.jl")
+```
+
+## Usage
+
+After installation, you can use this package by
+
+```julia
+using Matching
+```


### PR DESCRIPTION
I just mimicked the structure of QuantEcon.jl. [Here](https://shizejin.github.io/Matching.jl/latest/index.html) is what it will look like.

Before merge, please [add a branch `gh-pages`](https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#gh-pages-Branch-1) and [add SSH Deploy Keys](https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#SSH-Deploy-Keys-1).