### PR TITLE
Improve Performance

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -61,7 +61,7 @@ function _heap_bubble_up!(bh::BinMaxHeap)
 end
 
 function _heap_bubble_down!(bh::BinMaxHeap)
-    i = bh.ind
+    i = 1
     @inbounds r = bh.data[i]
     swapped = true
     n = length(bh)

--- a/src/util.jl
+++ b/src/util.jl
@@ -14,17 +14,6 @@ Base.getindex(bh::BinMaxHeap, ind::Int) = bh.data[ind]
 function top(bh::BinMaxHeap)
     return bh.data[1]
 end
-#function replace_least!(bh::BinMaxHeap, r::Int)
-#    r_least = least!(bh)
-#
-#    n = length(bh)
-#    bh.data[1] = bh.data[n]
-#    _heap_bubble_down!(bh, 1)
-#    bh.data[n] = v
-#    _heap_bubble_up!(bh, n)
-#
-#    return v_least
-#end
 
 # BEGIN: From DataStructures.jl/src/heaps/binary_heap.jl
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,5 +1,7 @@
 module Util
 
+import Base.==
+
 mutable struct BinMaxHeap{TD<:AbstractVector{Int}, TI<:Integer}
     data::TD
     ind::TI
@@ -7,19 +9,27 @@ end
 
 BinMaxHeap(cap::T) where {T <: Integer} = BinMaxHeap(Vector{Int}(cap), 0)
 
+==(bh1::BinMaxHeap, bh2::BinMaxHeap) = bh1.data[1:bh1.ind] == bh2.data[1:bh2.ind]
+
 Base.length(bh::BinMaxHeap) = bh.ind
 
 Base.getindex(bh::BinMaxHeap, ind::Int) = bh.data[ind]
 
 function top(bh::BinMaxHeap)
+    if bh.ind == 0
+        throw(BoundsError(
+            "attempt to access top of 0-element BinMaxheap"
+            )
+        )
+    end
     return bh.data[1]
 end
 
 # BEGIN: From DataStructures.jl/src/heaps/binary_heap.jl
 
 function push!(bh::BinMaxHeap, r::Int)
+    bh.data[bh.ind+1] = r
     bh.ind += 1
-    bh.data[bh.ind] = r
     _heap_bubble_up!(bh)
 end
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,78 +1,79 @@
 module Util
 
-mutable struct BinHeap{TR<:AbstractVector{Int},TD<:AbstractVector{Int}}
-    ranking::TR
+mutable struct BinMaxHeap{TD<:AbstractVector{Int}, TI<:Integer}
     data::TD
-    is_heapified::Bool
+    ind::TI
 end
 
-Base.length(bh::BinHeap) = length(bh.data)
+BinMaxHeap(cap::T) where {T <: Integer} = BinMaxHeap(Vector{Int}(cap), 0)
 
+Base.length(bh::BinMaxHeap) = bh.ind
 
-function heapify!(bh::BinHeap)
-    if bh.is_heapified
-        return bh
-    end
+Base.getindex(bh::BinMaxHeap, ind::Int) = bh.data[ind]
 
-    n = length(bh)
-    for i in 2:n
-        _heap_bubble_up!(bh, i)
-    end
-
-    bh.is_heapified = true
-    return bh
-end
-
-
-function least!(bh::BinHeap)
-    if !bh.is_heapified
-        heapify!(bh)
-    end
+function top(bh::BinMaxHeap)
     return bh.data[1]
 end
-
-
-function replace_least!(bh::BinHeap, v::Int)
-    v_least = least!(bh)
-
-    n = length(bh)
-    bh.data[1] = bh.data[n]
-    _heap_bubble_down!(bh, 1)
-    bh.data[n] = v
-    _heap_bubble_up!(bh, n)
-
-    return v_least
-end
-
+#function replace_least!(bh::BinMaxHeap, r::Int)
+#    r_least = least!(bh)
+#
+#    n = length(bh)
+#    bh.data[1] = bh.data[n]
+#    _heap_bubble_down!(bh, 1)
+#    bh.data[n] = v
+#    _heap_bubble_up!(bh, n)
+#
+#    return v_least
+#end
 
 # BEGIN: From DataStructures.jl/src/heaps/binary_heap.jl
 
-function _heap_bubble_up!(bh::BinHeap, i::Int)
-    i0::Int = i
-    @inbounds v = bh.data[i]
+function push!(bh::BinMaxHeap, r::Int)
+    bh.ind += 1
+    bh.data[bh.ind] = r
+    _heap_bubble_up!(bh)
+end
+
+function pop!(bh::BinMaxHeap)
+    max_r = bh.data[1]
+    bh.data[1] = bh.data[bh.ind]
+    bh.ind -= 1
+    if bh.ind != 0
+        _heap_bubble_down!(bh)
+    end
+    return max_r
+end
+
+function replace_least!(bh::BinMaxHeap, r::Int)
+    pop!(bh)
+    push!(bh, r)
+end
+
+function _heap_bubble_up!(bh::BinMaxHeap)
+    i::Int = bh.ind
+    @inbounds r = bh.data[i]
 
     while i > 1  # nd is not root
         p = i >> 1
-        @inbounds vp = bh.data[p]
+        @inbounds rp = bh.data[p]
 
-        if bh.ranking[v] > bh.ranking[vp]
+        if r > rp
             # move parent downward
-            @inbounds bh.data[i] = vp
+            @inbounds bh.data[i] = rp
             i = p
         else
             break
         end
     end
 
-    if i != i0
-        @inbounds bh.data[i] = v
+    if i != bh.ind
+        @inbounds bh.data[i] = r
     end
-
-    return bh
 end
 
-function _heap_bubble_down!(bh::BinHeap, i::Int)
-    @inbounds v = bh.data[i]
+function _heap_bubble_down!(bh::BinMaxHeap)
+    i = bh.ind
+    @inbounds r = bh.data[i]
     swapped = true
     n = length(bh)
     last_parent = n >> 1
@@ -81,27 +82,27 @@ function _heap_bubble_down!(bh::BinHeap, i::Int)
         lc = i << 1
         if lc < n   # contains both left and right children
             rc = lc + 1
-            @inbounds lv = bh.data[lc]
-            @inbounds rv = bh.data[rc]
-            if bh.ranking[rv] > bh.ranking[lv] #compare(comp, rv, lv)
-                if bh.ranking[rv] > bh.ranking[v]  #compare(comp, rv, v)
-                    @inbounds bh.data[i] = rv
+            @inbounds lr = bh.data[lc]
+            @inbounds rr = bh.data[rc]
+            if rr > lr #compare(comp, rv, lv)
+                if rr > r  #compare(comp, rv, v)
+                    @inbounds bh.data[i] = rr
                     i = rc
                 else
                     swapped = false
                 end
             else
-                if bh.ranking[lv] > bh.ranking[v]
-                    @inbounds bh.data[i] = lv
+                if lr > r
+                    @inbounds bh.data[i] = lr
                     i = lc
                 else
                     swapped = false
                 end
             end
         else        # contains only left child
-            @inbounds lv = bh.data[lc]
-            if bh.ranking[lv] > bh.ranking[v]
-                @inbounds bh.data[i] = lv
+            @inbounds lr = bh.data[lc]
+            if lr > r
+                @inbounds bh.data[i] = lr
                 i = lc
             else
                 swapped = false
@@ -109,9 +110,7 @@ function _heap_bubble_down!(bh::BinHeap, i::Int)
         end
     end
 
-    bh.data[i] = v
-
-    return bh
+    bh.data[i] = r
 end
 
 # END: From DataStructures.jl/src/heaps/binary_heap.jl

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,3 +3,4 @@ using Base.Test
 
 include("test_deferred_acceptance.jl")
 include("test_matching_tools.jl")
+include("test_util.jl")

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -1,4 +1,4 @@
-import MatchingMarkets.Util: BinMaxHeap, top, push!, pop!, replace_least!
+using MatchingMarkets.Util: BinMaxHeap, top, push!, pop!, replace_least!
 
 @testset "Testing util.jl" begin
 

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -1,53 +1,65 @@
-using MatchingMarkets.Util: BinMaxHeap, top, push!, pop!, replace_least!
+using MatchingMarkets.Util
 
 @testset "Testing util.jl" begin
 
     @testset "binary max heap" begin
-        bh1 = BinMaxHeap(10)
-        bh2 = BinMaxHeap(10)
-        bh3 = BinMaxHeap(10)
-        bh4 = BinMaxHeap(10)
-        bh5 = BinMaxHeap(10)
+        bh1 = Util.BinMaxHeap(10)
+        bh2 = Util.BinMaxHeap(10)
+        bh3 = Util.BinMaxHeap(10)
+        bh4 = Util.BinMaxHeap(10)
+        bh5 = Util.BinMaxHeap(10)
 
         @testset "empty heap equality" begin
             @test bh1 == bh2
         end
 
         @testset "accessing an empty heap" begin
-            @test_throws BoundsError top(bh1)
+            @test_throws BoundsError Util.top(bh1)
         end
 
         @testset "pop! from an empty heap" begin
-            @test_throws BoundsError pop!(bh1)
+            @test_throws BoundsError Util.pop!(bh1)
         end
 
         @testset "heap ordered" begin
             for i in [3, 2, 10, 6, 5, 9, 7, 1, 4, 8]
-                push!(bh2, i)
+                Util.push!(bh2, i)
             end
             for i in 10:-1:1
-                @test pop!(bh2) == i
+                @test Util.pop!(bh2) == i
             end
             for i in [1, 8, 2, 3, 6, 5, 4, 7, 10, 9]
-                push!(bh2, i)
+                Util.push!(bh2, i)
             end
             for i in 10:-1:1
-                @test pop!(bh2) == i
+                @test Util.pop!(bh2) == i
             end
         end
 
         @testset "length of heap" begin
             for i in 1:10
-                push!(bh3, i)
+                Util.push!(bh3, i)
                 @test length(bh3) == i
             end
         end
 
-        @testset "pushing to full heap not accepted" begin
+        @testset "pushing to full heap not allowed" begin
             for i in 1:10
-                push!(bh4, i)
+                Util.push!(bh4, i)
             end
-            @test_throws BoundsError push!(bh4, 11)
+            @test_throws BoundsError Util.push!(bh4, 11)
+        end
+
+        @testset "least replacement" begin
+            for i in 10:-1:1
+                Util.push!(bh5, i)
+            end
+            Util.replace_least!(bh5, 11)
+            @test Util.top(bh5) == 11
+            Util.replace_least!(bh5, 10)
+            @test Util.top(bh5) == 10
+            Util.replace_least!(bh5, 9)
+            @test Util.top(bh5) == 9
         end
     end
 

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -1,0 +1,54 @@
+import MatchingMarkets.Util: BinMaxHeap, top, push!, pop!, replace_least!
+
+@testset "Testing util.jl" begin
+
+    @testset "binary max heap" begin
+        bh1 = BinMaxHeap(10)
+        bh2 = BinMaxHeap(10)
+        bh3 = BinMaxHeap(10)
+        bh4 = BinMaxHeap(10)
+        bh5 = BinMaxHeap(10)
+
+        @testset "empty heap equality" begin
+            @test bh1 == bh2
+        end
+
+        @testset "accessing an empty heap" begin
+            @test_throws BoundsError top(bh1)
+        end
+
+        @testset "pop! from an empty heap" begin
+            @test_throws BoundsError pop!(bh1)
+        end
+
+        @testset "heap ordered" begin
+            for i in [3, 2, 10, 6, 5, 9, 7, 1, 4, 8]
+                push!(bh2, i)
+            end
+            for i in 10:-1:1
+                @test pop!(bh2) == i
+            end
+            for i in [1, 8, 2, 3, 6, 5, 4, 7, 10, 9]
+                push!(bh2, i)
+            end
+            for i in 10:-1:1
+                @test pop!(bh2) == i
+            end
+        end
+
+        @testset "length of heap" begin
+            for i in 1:10
+                push!(bh3, i)
+                @test length(bh3) == i
+            end
+        end
+
+        @testset "pushing to full heap not accepted" begin
+            for i in 1:10
+                push!(bh4, i)
+            end
+            @test_throws BoundsError push!(bh4, 11)
+        end
+    end
+
+end


### PR DESCRIPTION
This pull request improves the performance of `deferred_acceptance` function by these modifications.

1. Struct `BinMaxHeap`(former `BinHeap`) now only has a field `data`, which corresponds to the field `ranking` of the original version.

1. Introduce stack-like structure to reduce the number of main loops.

Notes on changes above are [here](http://nbviewer.jupyter.org/github/nswa17/Mn/blob/master/Julia/MatchingMarkets/RevisionSummary.ipynb?flush_cache=true)(Japanese).

Also, further performance improvement can be done if it's ok to limit the maximum number of responders, proposers up to 65535.